### PR TITLE
Issue #187: Addressing hangup when loading Aquifer data with TP data.elements equal NA

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: wateRuse
 Type: Package
 Title: wateRuse data analysis functions
 Version: 1.0.7
-Date: 2016-12-06
+Date: 2017-04-27
 Authors@R: c( person("Robert", "Dudley", role = c("aut", "cre"),
     email = "rwdudley@usgs.gov"),
     person("Laura","DeCicco", role = "aut"),

--- a/R/compare_two_years.R
+++ b/R/compare_two_years.R
@@ -29,7 +29,9 @@
 compare_two_years <- function(w.use, data.elements, year.x.y, area.column, areas=NA, 
                               legend = FALSE,
                               c.palette = c("#999999", "#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2", "#D55E00", "#CC79A7")){ 
-
+  
+  data.elements <- data.elements[which(!is.na(data.elements))]
+  
   w.use.sub <- subset_wuse(w.use, data.elements, area.column, areas)
   
   w.use.sub <-  w.use.sub[w.use.sub$YEAR %in% year.x.y,] 

--- a/R/subset_wuse.R
+++ b/R/subset_wuse.R
@@ -20,6 +20,10 @@
 #' w.use.sub <- subset_wuse(w.use, data.elements,area.column,areas)
 subset_wuse <- function(w.use, data.elements, area.column, areas=NA) {
   # subset w.use on basis of areas and select the data elements of interest
+  # if (all(is.na(data.elements))){
+  #   stop("All data.elements cannot be NA.")
+  # }
+  data.elements <- data.elements[which(!is.na(data.elements))]
   if (all(is.na(areas))){
     w.use.sub <- w.use[,c("YEAR",area.column,data.elements)]
   }else{


### PR DESCRIPTION
First plot in Shiny Compare_Two_Years expects TP, which is now absent in the Aquifer data, causing data.elements to be NA. This seems to cause hangup upon load of Aquifer data.  Added following statement to use only values of data.elements that are not NAs.:
data.elements <- data.elements[which(!is.na(data.elements))]

Still hanging up but seems to get beyond the TP worksheet to the PS worksheet when loading Aquifer data. @ldecicco-USGS @rwdudley-usgs @jshourds-usgs @lindsaycarr 