### PR TITLE
Addresses enhancement issue #155 Outlier Detection. 

### DIFF
--- a/R/compare_two_years.R
+++ b/R/compare_two_years.R
@@ -26,8 +26,9 @@
 #' compare_two_years(w.use, data.elements, year.x.y, area.column, areas)
 #' compare_two_years(w.use, data.elements, year.x.y, area.column)
 #' compare_two_years(w.use, "PS.TOPop", year.x.y, area.column)
+#' compare_two_years(w.use, "PS.TOPop", year.x.y, area.column, pctDiff = 50, valDiff = 100)
 compare_two_years <- function(w.use, data.elements, year.x.y, area.column, areas=NA, 
-                              legend = FALSE,
+                              legend = FALSE, pctDiff = 0, valDiff = 0, log.oper = "and",
                               c.palette = c("#999999", "#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2", "#D55E00", "#CC79A7")){ 
 
   data.elements <- data.elements[which(!is.na(data.elements))]
@@ -59,7 +60,19 @@ compare_two_years <- function(w.use, data.elements, year.x.y, area.column, areas
     if(all(is.na(df_x)) | nrow(df_x) == 0) stop('No Data Available for First Year Selected')
     
     if(all(is.na(df_y)) | nrow(df_y) == 0) stop('No Data Available for Second Year Selected')
-    
+
+    # apply outlier crtieria
+    if (pctDiff != 0 | valDiff != 0){
+      df$pctDiff <- abs(round((df$y - df$x) / df$x * 100, 1))
+      df$valDiff <- abs(df$y - df$x)
+      if (log.oper == "and"){
+        df <- df[which(df$pctDiff >= pctDiff & df$valDiff >= valDiff),]
+      }else{
+        df <- df[which(df$pctDiff >= pctDiff | df$valDiff >= valDiff),]
+      }
+      df <- df[,c("site", "x", "y")]
+    }
+
     df$Key <- i
     
     if(i == data.elements[1]){

--- a/inst/shiny/plotTwo.R
+++ b/inst/shiny/plotTwo.R
@@ -18,10 +18,15 @@ plotTwo <- reactive({
   }
   legend <- input$legendOn
   
+  pctDiff <- input$pctDiff
+  valDiff <- input$valDiff
+  log.oper <- input$logOperSelect
+  
   area.column <- df[["area.column"]]
   year.x.y <- c(input$year_x,input$year_y)
 
-  plotTwo <- compare_two_years(w.use, data.elements, year.x.y, area.column, areas = areas.p2, legend=legend)
+  plotTwo <- compare_two_years(w.use, data.elements, year.x.y, area.column,
+    areas = areas.p2, legend=legend, pctDiff = pctDiff, valDiff = valDiff, log.oper = log.oper)
   
   write.csv(x = plotTwo$data, file = "plotTwoYears.csv", row.names = FALSE)
   
@@ -61,7 +66,9 @@ output$plotTwoCode <- renderPrint({
   data.elements <- input$data.elements
   areas.ptC <- df[["area"]]
   legend <- input$legendOn
-  
+  pctDiff <- input$pctDiff
+  valDiff <- input$valDiff
+  log.oper <- input$logOperSelect
   areasOptions <- df[["areas"]]
   
   if(all(areasOptions %in% areas.ptC)){
@@ -79,7 +86,10 @@ output$plotTwoCode <- renderPrint({
     'area.column <- "', area.column, '"\n',
     "year.x.y <- c(",paste0(year.x.y,collapse = ","),")\n",
     "legend <- ", legend, "\n",
-    "compare_two_years(w.use, data.elements, year.x.y, area.column, areas, legend)"
+    "pctDiff <- ", pctDiff, "\n",
+    "valDiff <- ", valDiff, "\n",
+    "log.oper <- ", log.oper, "\n",
+    "compare_two_years(w.use, data.elements, year.x.y, area.column, areas, legend, pctDiff, valDiff, log.oper)"
     
   )
   

--- a/inst/shiny/ui.R
+++ b/inst/shiny/ui.R
@@ -213,6 +213,14 @@ sidebar <- dashboardSidebar(
     checkboxInput("legendOn", label = "Include Legend", value = FALSE)
   ),
   conditionalPanel(
+    condition = "input.mainTabs == 'plotTwoTab' ",
+    menuItem("Identify Outliers", icon = icon("th"), tabName = "outlierTab",
+      numericInput("pctDiff", label = "Percent difference greater than or equal to (absolute value)", value =0, min = 0),
+      radioButtons("logOperSelect", label = "", choices = c("and","or"), selected = "and"),
+      numericInput("valDiff", label = "Value difference greater than or equal to (absolute value)", value = 0, min = 0))
+  ),
+  
+  conditionalPanel(
     condition = "input.mainTabs == 'multiElem' | input.mainTabs == 'boxPlotTab' | input.mainTabs == 'plotTimeTab' | input.mainTabs == 'rankData'",
     checkboxGroupInput("whatYears", label = "Years", choices = c("1990","2010"), selected = "2010")
   ),


### PR DESCRIPTION
Changes provide ability to specify outlier thresholds both in percent and/or absolute value for  `plotTwoTab` (comparing two years). When the `plotTwoTab` is selected, a conditional panel appears on the left to `Identify Outliers` where criteria can be specified. By default, values are set to zero.